### PR TITLE
Legacy SQL option via env var

### DIFF
--- a/R/bigquery.R
+++ b/R/bigquery.R
@@ -231,10 +231,13 @@ bqExecuteSql <- function(sql, ...) {
     sql <- sql
   }
 
+  use.legacy.sql <- Sys.getenv("BIGQUERY_LEGACY_SQL", unset = "TRUE") == "TRUE"
+
   res <- query_exec(sql,
                     project = Sys.getenv("BIGQUERY_PROJECT"),
                     default_dataset = Sys.getenv("BIGQUERY_DATASET"),
-                    max_pages = Inf)
+                    max_pages = Inf,
+                    use_legacy_sql = use.legacy.sql)
   return(data.table(res))
 }
 

--- a/tests/testthat/test.bq.query.R
+++ b/tests/testthat/test.bq.query.R
@@ -9,11 +9,11 @@ test_that("Correct sql is executed", {
     {
       res <- bqExecuteSql("SELECT %1$s", "TEST")
       expect <- "SELECT TEST"
-      expect_args(query_function, 1,  sql = expect, project = "", default_dataset = "", max_pages = Inf)
+      expect_args(query_function, 1,  sql = expect, project = "", default_dataset = "", max_pages = Inf, TRUE)
 
       res <- bqExecuteFile("sample_query.sql", 100)
       expect <- "SELECT TEST_100"
-      expect_args(query_function, 2,  sql = expect, project = "", default_dataset = "", max_pages = Inf)
+      expect_args(query_function, 2,  sql = expect, project = "", default_dataset = "", max_pages = Inf, TRUE)
     }
   )
 })


### PR DESCRIPTION
Adding BIGQUERY_LEGACY_SQL as environment variable to allow the switch in SQL syntax. It will default to legacy sql if variable is not set in your project.