### PR TITLE
Adding option to use BigQuery parameters in SQL templates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: retl
 Type: Package
 Title: Support for common ETL operations and connections
-Version: 0.1.3.0
+Version: 0.1.4
 Date: 2018-09-30
 Author: byapparov@gmail.com
 Maintainer: Bulat Yapparov <byapparov@gmail.com>

--- a/R/bigquery.R
+++ b/R/bigquery.R
@@ -499,6 +499,8 @@ bqExecuteQuery <- function(query, ...) {
 #'
 #' @export
 #' @param sql string with sql statement
+#' @param use.legacy.sql switches SQL dialect.
+#'   Defaults to value set in `BIGQUERY_LEGACY_SQL` env.
 bqExecuteSql <- function(sql, ..., use.legacy.sql = bqUseLegacySql()) {
   if (length(list(...)) > 0) {
     # template requires parameters.

--- a/R/bigquery.R
+++ b/R/bigquery.R
@@ -507,8 +507,9 @@ bqExecuteSql <- function(sql, ..., use.legacy.sql = bqUseLegacySql()) {
     # template does not have parameteres.
     sql <- sql
   }
-  args <- c(as.list(environment()), list(...))
 
+  # Extract named arguments and turn them into query params
+  args <- c(as.list(environment()), list(...))
   args.names <- names(args)
   param.names <- args.names[nchar(args.names) > 0] # keep arguments wit
   param.names <- setdiff(param.names, c("sql", "use.legacy.sql")) # exclude sql from parameters

--- a/R/bigquery.R
+++ b/R/bigquery.R
@@ -509,7 +509,7 @@ bqExecuteSql <- function(sql, ..., use.legacy.sql = bqUseLegacySql()) {
   params <- named_arguments(args, args.reserved)
 
   assert_that(
-    !use.legacy.sql & !(length(params) > 0L & noname_arguments_count(args) > 0L),
+    !use.legacy.sql & !(length(params) > 0L & noname_items_count(args) > 0L),
     msg = "Don't mix named and anonymous parameters in the call."
   )
 
@@ -556,10 +556,11 @@ named_arguments <- function(args, reserved) {
   args[args.names]
 }
 
-noname_arguments_count <- function(args) {
-  args.names <- names(args)
-  args.names <- args.names[nchar(args.names) == 0]
-  length(args.names)
+#' Counts number of items in the list that don't have names
+#'
+#' @noRd
+noname_items_count <- function(x) {
+  sum(nchar(names(x)) == 0)
 }
 
 

--- a/R/bigquery.R
+++ b/R/bigquery.R
@@ -362,14 +362,16 @@ readSql <- function(file, ...) {
 #' @param sql SQL statement to use a source for a new table
 #' @param table name of a table to be created
 #' @param dataset name of the destination dataset
-#' @param write_disposition defines whether records will be appended
+#' @param write.disposition defines whether records will be appended
 #' @param priority sets priority of job execution to INTERACTIVE or BATCH
+#' @param use.legacy.sql allows to switch between BigQuery SQL dialects
 #' @return results of the execution as returned by bigrquery::query_exec
 bqCreateTable <- function(sql,
                           table,
                           dataset = bqDefaultDataset(),
-                          write_disposition = "WRITE_APPEND",
-                          priority = "INTERACTIVE") {
+                          write.disposition = "WRITE_APPEND",
+                          priority = "INTERACTIVE",
+                          use.legacy.sql = bqUseLegacySql()) {
   bqAuth()
   tbl <- bq_table(
     project = bqDefaultProject(),
@@ -386,8 +388,8 @@ bqCreateTable <- function(sql,
     destination_table = tbl,
     default_dataset = ds,
     create_disposition = "CREATE_IF_NEEDED",
-    write_disposition = write_disposition,
-    use_legacy_sql = bqUseLegacySql(),
+    write_disposition = write.disposition,
+    use_legacy_sql = use.legacy.sql,
     priority = priority
   )
   if (priority == "INTERACTIVE") {
@@ -738,11 +740,11 @@ bqCopyTable <- function(from, to, override = TRUE) {
     table_id = to
   )
 
-  write_disposition <- ifelse(override, "WRITE_TRUNCATE", "WRITE_EMPTY")
+  write.disposition <- ifelse(override, "WRITE_TRUNCATE", "WRITE_EMPTY")
   bq_table_copy(
     x = src,
     dest = dest,
-    write_disposition = write_disposition
+    write_disposition = write.disposition
   )
 
   return(bqTableExists(to))
@@ -818,7 +820,7 @@ bqTransformPartition <- function(table, file, ..., priority = "INTERACTIVE") {
     bqCreateTable(
       sql.exec,
       table = destination.partition,
-      write_disposition = "WRITE_TRUNCATE",
+      write.disposition = "WRITE_TRUNCATE",
       priority = priority
     )
   })
@@ -841,7 +843,7 @@ bqRefreshPartitionData <- function(table, file, ..., priority = "BATCH") {
     bqCreateTable(
       sql = sql,
       table = destination.partition,
-      write_disposition = "WRITE_TRUNCATE",
+      write.disposition = "WRITE_TRUNCATE",
       priority = priority
     )
   })

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ BigQuery functions wrap `bigrquery` functions to provide higher level API removi
 
 ### query data
 
+You can parameterise your SQL using positional matching (`sprintf`) if you don't name arguments in the call to `bqExecuteQuery()`:
+
 ```R
 # Running query to get the sie of group A
 dt <- bqExecuteQuery("SELECT COUNT(*) as size FROM my_table WHERE group = `%1$s`", "A")

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ dt <- bqExecuteQuery(
 )
 ```
 
-In example above `group` argument will be matched with the `@group` paramter and BigQuery will execute 
+In the example above `group` argument will be matched with `@group` paramter and BigQuery will execute 
 the following query:
 
 ```SQL
@@ -50,7 +50,7 @@ SELECT
 FROM 
   my_table
 WHERE 
-  group = 'A'
+  group = 'A' -- parameter is replaced by matching argument in the call
 ```
 
 ### dataset

--- a/README.md
+++ b/README.md
@@ -30,6 +30,30 @@ dt <- bqExecuteQuery("SELECT COUNT(*) as size FROM my_table WHERE group = `%1$s`
 dt <-  bqExecuteFile("group-size.sql", "A")
 ```
 
+You can use [parameters](https://cloud.google.com/bigquery/docs/parameterized-queries) in the query template with standard SQL. You have to give matching names to arguments in `bqExecuteQuery()` call:
+
+# Running query to get the sie of group A
+
+```R
+dt <- bqExecuteQuery(
+  sql = "SELECT COUNT(*) as size FROM my_table WHERE group = @group", 
+  group = "A",
+  use.legacy.sql = FALSE
+)
+```
+
+In example above `group` argument will be matched with `@group` paramter and BigQuery will execute 
+the this query:
+
+```SQL
+SELECT 
+  COUNT(*) as size 
+FROM 
+  my_table
+WHERE 
+  group = 'A'
+```
+
 ### dataset
 
 ```R
@@ -125,24 +149,6 @@ dt <- s3GetData("path/to/myfile_")
 ```
 
 ## Schema for metadata ##
-
-### etl_jobs ###
-
-Field Name | Type | Description
------------|------|------------
-__job__ | STRING | Key for the job. Example: `crm.tranfer.cutomers`.
-__increment_name__ | STRING | Name of the field that is used as incrment key.
-__increment_type__ |STRING | Type of the field that is used as incrment key. Acceptable values: `INTEGER`, `DATE`.
-
-
-### etl_increments ###
-
-Field Name | Type | Description
------------|------|------------
-__job__ | STRING | Foreign key to the `etl_jobs` table.
-__increment_value__ | STRING | maximum value in of the incrment key in the processed dataset.
-__records__ |INTEGER | Number of records processed by the etl job.
-__datetime__ | TIMESTAMP | Time when job was executed.
 
 ### model_performance ###
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ dt <-  bqExecuteFile("group-size.sql", "A")
 
 You can use [parameters](https://cloud.google.com/bigquery/docs/parameterized-queries) in the query template with standard SQL. You have to give matching names to arguments in `bqExecuteQuery()` call:
 
-# Running query to get the sie of group A
-
 ```R
+# Running query to get the sie of group A
 dt <- bqExecuteQuery(
   sql = "SELECT COUNT(*) as size FROM my_table WHERE group = @group", 
   group = "A",
@@ -42,8 +41,8 @@ dt <- bqExecuteQuery(
 )
 ```
 
-In example above `group` argument will be matched with `@group` paramter and BigQuery will execute 
-the this query:
+In example above `group` argument will be matched with the `@group` paramter and BigQuery will execute 
+the following query:
 
 ```SQL
 SELECT 

--- a/man/bqCreateTable.Rd
+++ b/man/bqCreateTable.Rd
@@ -5,7 +5,8 @@
 \title{Creates table using given sql}
 \usage{
 bqCreateTable(sql, table, dataset = bqDefaultDataset(),
-  write_disposition = "WRITE_APPEND", priority = "INTERACTIVE")
+  write.disposition = "WRITE_APPEND", priority = "INTERACTIVE",
+  use.legacy.sql = bqUseLegacySql())
 }
 \arguments{
 \item{sql}{SQL statement to use a source for a new table}
@@ -14,9 +15,11 @@ bqCreateTable(sql, table, dataset = bqDefaultDataset(),
 
 \item{dataset}{name of the destination dataset}
 
-\item{write_disposition}{defines whether records will be appended}
+\item{write.disposition}{defines whether records will be appended}
 
 \item{priority}{sets priority of job execution to INTERACTIVE or BATCH}
+
+\item{use.legacy.sql}{allows to switch between BigQuery SQL dialects}
 }
 \value{
 results of the execution as returned by bigrquery::query_exec

--- a/man/bqInsertData.Rd
+++ b/man/bqInsertData.Rd
@@ -5,7 +5,7 @@
 \title{Inserts data into BigQuery table}
 \usage{
 bqInsertData(table, data, dataset = bqDefaultDataset(), append = TRUE,
-  fields = as_bq_fields(data))
+  fields = NULL)
 }
 \arguments{
 \item{table}{name of the target table}

--- a/man/bqQuery.Rd
+++ b/man/bqQuery.Rd
@@ -14,7 +14,7 @@ bqExecuteFile(file, ...)
 
 bqExecuteQuery(query, ...)
 
-bqExecuteSql(sql, ...)
+bqExecuteSql(sql, ..., use.legacy.sql = bqUseLegacySql())
 }
 \arguments{
 \item{sql}{string with sql statement}
@@ -24,6 +24,9 @@ bqExecuteSql(sql, ...)
 \item{...}{any parameters that will be used to fill in placeholders with sprintf}
 
 \item{query}{template of the sql statement}
+
+\item{use.legacy.sql}{switches SQL dialect.
+Defaults to value set in `BIGQUERY_LEGACY_SQL` env.}
 }
 \value{
 results of execution as data.table

--- a/news.md
+++ b/news.md
@@ -1,13 +1,13 @@
-# Package Updates
+# RETL Package Updates
  
-## retl 0.1.4
+## 0.1.4
 
 * `bqExecuteQuery()`, `bqExecuteSql()`, `bqExecuteFile()` - (#93, @byapparov)
   - Resulting column names in data.table conformed to have words separated by dot: `my.field.name`;
   - `use.legacy.sql` argument is available to switch between SQL dialects in BigQuery.
   - named arguments to these functions will be turned to query params if standard dialect is used.
 
-## retl 0.1.3
+## 0.1.3
 
 * `bqImportData()` - allows to import GS file into BigQuery table. By default imports mirror file from `table-name.csv.gz`. Format and compression params control file extension. 
 
@@ -33,7 +33,7 @@
   into a single body request. This is a breaking change as `custom.metrics` param is now 
   a list of vectors.
 
-## retl 0.1.2
+## 0.1.2
 
 * `s3GetFile()`, `s3PutFile()` - functions are changed to read data based on the extention of the file. Fore example you can use it instead of calling `s3GetFile.csv()` if path ends with `.csv`.
 
@@ -54,7 +54,7 @@
 
 * `s3ListFiles()` - gets metadata of s3 files matching give path into data.table (#80)
 
-## retl 0.1.1
+## 0.1.1
 
 * Lower level BigQuery API calls are updated to the new functions from bigrquery 1.0.0
 
@@ -64,7 +64,7 @@
 
 * `bqTableSchema()` loads table schema `bq_fields` object
 
-## retl 0.1.0
+## 0.1.0
 
 * `influxLog()`, `influxConnection()` changed the API of the influx wrapper functions to default values. (#64, @byapparov)
 

--- a/news.md
+++ b/news.md
@@ -2,7 +2,7 @@
  
 ## retl 0.1.4
 
-* `bqExecuteQuery()`, `bqExecuteSql()`, `bqExecuteFile()` 
+* `bqExecuteQuery()`, `bqExecuteSql()`, `bqExecuteFile()` - (#93, @byapparov)
   - Resulting column names in data.table conformed to have words separated by dot: `my.field.name`;
   - `use.legacy.sql` argument is available to switch between SQL dialects in BigQuery.
   - named arguments to these functions will be turned to query params if standard dialect is used.

--- a/news.md
+++ b/news.md
@@ -1,4 +1,13 @@
-# retl 0.1.3
+# Package Updates
+ 
+## retl 0.1.4
+
+* `bqExecuteQuery()`, `bqExecuteSql()`, `bqExecuteFile()` 
+  - Resulting column names in data.table conformed to have words separated by dot: `my.field.name`;
+  - `use.legacy.sql` argument is available to switch between SQL dialects in BigQuery.
+  - named arguments to these functions will be turned to query params if standard dialect is used.
+
+## retl 0.1.3
 
 * `bqImportData()` - allows to import GS file into BigQuery table. By default imports mirror file from `table-name.csv.gz`. Format and compression params control file extension. 
 
@@ -24,7 +33,7 @@
   into a single body request. This is a breaking change as `custom.metrics` param is now 
   a list of vectors.
 
-# retl 0.1.2
+## retl 0.1.2
 
 * `s3GetFile()`, `s3PutFile()` - functions are changed to read data based on the extention of the file. Fore example you can use it instead of calling `s3GetFile.csv()` if path ends with `.csv`.
 
@@ -45,7 +54,7 @@
 
 * `s3ListFiles()` - gets metadata of s3 files matching give path into data.table (#80)
 
-# retl 0.1.1
+## retl 0.1.1
 
 * Lower level BigQuery API calls are updated to the new functions from bigrquery 1.0.0
 
@@ -55,7 +64,7 @@
 
 * `bqTableSchema()` loads table schema `bq_fields` object
 
-# retl 0.1.0
+## retl 0.1.0
 
 * `influxLog()`, `influxConnection()` changed the API of the influx wrapper functions to default values. (#64, @byapparov)
 

--- a/news.md
+++ b/news.md
@@ -2,6 +2,9 @@
  
 ## 0.1.4
 
+* `bqCreateTable()` 
+  - you can switch between SQL dialects. Parameters are not available yet.
+  - `write_disposition` argument was renamed to `write.disposition`.
 * `bqExecuteQuery()`, `bqExecuteSql()`, `bqExecuteFile()` - (#93, @byapparov)
   - Resulting column names in data.table conformed to have words separated by dot: `my.field.name`;
   - `use.legacy.sql` argument is available to switch between SQL dialects in BigQuery.


### PR DESCRIPTION
- Conform headers automatically for data extracted from BigQuery

- Extract parameters with names from the argument list and pass to BigQuery API if standard SQL is used

- Automatically snakecase colnames for the data.table imported into BigQuery