### PR TITLE
Print of parameters works with bq_param classes.

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,3 +1,3 @@
 linters: with_defaults(
-    object_name_linter = object_name_linter(c("lowerCamelCase", "dotted.case")),
+    object_name_linter = object_name_linter(c("camelCase", "dotted.case")),
     line_length_linter = line_length_linter(120))

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: retl
 Type: Package
 Title: Support for common ETL operations and connections
-Version: 0.1.16
+Version: 0.1.17
 Date: 2019-09-12
 Author: byapparov@gmail.com
 Maintainer: Bulat Yapparov <byapparov@gmail.com>

--- a/R/bigquery-defaults.R
+++ b/R/bigquery-defaults.R
@@ -7,6 +7,7 @@ bqUseLegacySql <- function(x = NULL) {
     Sys.getenv("BIGQUERY_LEGACY_SQL", unset = "TRUE") == "TRUE"
   }
   else {
+    .Deprecated("bqExecuteQuery", msg = "Use `use.legacy.sql` parameter instead.")
     Sys.setenv("BIGQUERY_LEGACY_SQL" = x)
   }
 }

--- a/R/bigquery-execute.R
+++ b/R/bigquery-execute.R
@@ -56,7 +56,7 @@ bqExecuteSql <- function(sql, ..., use.legacy.sql = bqUseLegacySql()) {
 
   if (!use.legacy.sql & length(params) > 0) {
     cat("parameters applied to the template: \n")
-    print(jsonlite::toJSON(params, auto_unbox = TRUE))
+    print(jsonlite::toJSON(params, auto_unbox = TRUE, force = TRUE))
   } else {
     params <- NULL
   }

--- a/R/bigquery-partition.R
+++ b/R/bigquery-partition.R
@@ -237,4 +237,3 @@ bqDatasetLabel <- function(datasets, dataset) {
   names(labels) <- datasets
   return(labels[as.character(dataset)])
 }
-

--- a/news.md
+++ b/news.md
@@ -1,5 +1,9 @@
 # RETL Package Updates
 
+## 0.1.17
+
+* `bqExecuteSql()` - #127 is resolved, now you can pass parameters to query with explicit `bq_param_array` class (@byapparov, #129)
+
 ## 0.1.16
 
 * `dcWriteCustomMetics` - add the correction for the binary read

--- a/tests/testthat/test.bq.insert.R
+++ b/tests/testthat/test.bq.insert.R
@@ -123,7 +123,7 @@ withr::with_envvar(
           BIGQUERY_END_DATE = "2015-01-02"),
   action = "replace",
   test_that("shard tables from several datasets can
-            be tranformed in day partitioned tables", {
+            be transformed in day partitioned tables", {
     datasets <- c(a = "ds_retl_test_1", b = "ds_retl_test_2")
     lapply(datasets, function(ds) {
       if (bqDatasetExists(ds)) {

--- a/tests/testthat/test.bq.query.R
+++ b/tests/testthat/test.bq.query.R
@@ -1,5 +1,3 @@
-library(bigrquery)
-library(mockery)
 context("BigQuery query functions.")
 
 test_that("Correct sql is executed", {
@@ -31,6 +29,14 @@ test_that("Parameter can be used with a vector", {
     sql = "SELECT * FROM (SELECT 'A' AS test) t
            WHERE test IN UNNEST(@tests)",
     tests = c("A", "B"),
+    use.legacy.sql = FALSE
+  )
+  expect_equal(res$test, "A")
+
+  res <- bqExecuteSql(
+    sql = "SELECT * FROM (SELECT 'A' AS test) t
+           WHERE test IN UNNEST(@tests)",
+    tests = bigrquery::bq_param_array("A"),
     use.legacy.sql = FALSE
   )
   expect_equal(res$test, "A")

--- a/tests/testthat/test.bq.query.R
+++ b/tests/testthat/test.bq.query.R
@@ -33,6 +33,7 @@ test_that("Parameter can be used with a vector", {
   )
   expect_equal(res$test, "A")
 
+  # Param values passed as explicit object should work
   res <- bqExecuteSql(
     sql = "SELECT * FROM (SELECT 'A' AS test) t
            WHERE test IN UNNEST(@tests)",
@@ -40,6 +41,16 @@ test_that("Parameter can be used with a vector", {
     use.legacy.sql = FALSE
   )
   expect_equal(res$test, "A")
+
+  # Named values passed to paramaterised query should also work
+  res <- bqExecuteSql(
+    sql = "SELECT * FROM (SELECT 'A' AS test) t
+           WHERE test IN UNNEST(@tests)",
+    tests = c(a = "A", b = "B"),
+    use.legacy.sql = FALSE
+  )
+  expect_equal(res$test, "A")
+
 })
 
 test_that("Correct sql statement is read", {

--- a/tests/testthat/test.z.lintr.R
+++ b/tests/testthat/test.z.lintr.R
@@ -10,7 +10,7 @@ if (requireNamespace("lintr", quietly = TRUE)) {
         lintr::assignment_linter,
         lintr::closed_curly_linter,
         lintr::absolute_path_linter,
-        lintr::object_name_linter(c("lowerCamelCase", "dotted.case"))
+        lintr::object_name_linter(c("camelCase", "dotted.case"))
       )
     )
   })


### PR DESCRIPTION
Resolves: #127 

Note: this version will work with the latest version of `byapparov/bigrquery`:
- commit hash: [5e7b5bc](https://github.com/byapparov/bigrquery/commit/5e7b5bc14849f0797e7bde3e43c7cb166a358b40)