### PR TITLE
AT-1240: Update insert functions to prevent table drop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: retl
 Type: Package
 Title: Support for common ETL operations and connections
-Version: 0.1.23
+Version: 0.1.24
 Date: 2019-10-21
 Author: byapparov@gmail.com
 Maintainer: Bulat Yapparov <byapparov@gmail.com>

--- a/man/bqInsertData.Rd
+++ b/man/bqInsertData.Rd
@@ -5,7 +5,7 @@
 \title{Inserts data into BigQuery table}
 \usage{
 bqInsertData(table, data, dataset = bqDefaultDataset(), append = TRUE,
-  fields = NULL)
+  fields = NULL, schema.file = NULL)
 }
 \arguments{
 \item{table}{name of the target table}
@@ -17,6 +17,8 @@ bqInsertData(table, data, dataset = bqDefaultDataset(), append = TRUE,
 \item{append}{specifies if data should be appended or truncated}
 
 \item{fields}{list of fields with names and types (as bq_fields)}
+
+\item{schema.file}{sets path to schema file for initialisation}
 }
 \value{
 results of execution

--- a/man/bqInsertLargeData.Rd
+++ b/man/bqInsertLargeData.Rd
@@ -5,7 +5,7 @@
 \title{Inserts LARGE data into BigQuery table}
 \usage{
 bqInsertLargeData(table, data, dataset = bqDefaultDataset(),
-  chunks = 5, append = TRUE)
+  chunks = 5, append = TRUE, schema.file = NULL)
 }
 \arguments{
 \item{table}{name of the target table}
@@ -17,6 +17,8 @@ bqInsertLargeData(table, data, dataset = bqDefaultDataset(),
 \item{chunks}{number of segments the data should be split into}
 
 \item{append}{specifies if data should be appended or truncated}
+
+\item{schema.file}{sets path to schema file for initialisation}
 }
 \value{
 results of execution

--- a/news.md
+++ b/news.md
@@ -1,5 +1,10 @@
 # RETL Package Updates
 
+## 0.1.24
+
+* `bqInsertData()` - add initiation capability via argument schema.file
+* `bqInsertLargeData()` - add initiation capability via argument schema.file
+
 ## 0.1.23
 
 * `bqCreateTable()` - add initiation capability via argument schema.file


### PR DESCRIPTION
- bqInsertData updated to include a schema.file parameter which when provided deletes all rows of the table and attempts to patch additional fields
- bqInsertLargeData updated to include a schema.file parameter which when provided deletes all rows of the table and attempts to patch additional fields