### PR TITLE
AT-1271: Upgrade Google Sheets functions with new params

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,4 +1,4 @@
 Sys.setenv(TZ = "UTC")
-#### -- Packrat Autoloader (version 0.4.8-1) -- ####
+#### -- Packrat Autoloader (version 0.5.0) -- ####
 source("packrat/init.R")
 #### -- End Packrat Autoloader -- ####

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: retl
 Type: Package
 Title: Support for common ETL operations and connections
-Version: 0.1.26
+Version: 0.1.27
 Date: 2019-10-22
 Author: byapparov@gmail.com
 Maintainer: Bulat Yapparov <byapparov@gmail.com>
@@ -17,7 +17,7 @@ Suggests:
     sodium,
     googleAuthR,
     R.utils
-RoxygenNote: 6.1.1.9000
+RoxygenNote: 7.0.2
 Imports:
     aws.s3 (>= 0.3.2),
     bigrquery (>= 1.2.0),

--- a/R/googlespreadsheets.R
+++ b/R/googlespreadsheets.R
@@ -34,7 +34,7 @@ gsLoadSheet <- function(key,
   gsAuth()
   gap <- gs_key(
     x = key,
-    verbose = TRUE,
+    verbose = verbose,
     lookup = lookup,
     visibility = visibility
     )

--- a/R/googlespreadsheets.R
+++ b/R/googlespreadsheets.R
@@ -21,24 +21,50 @@ gsAuth <- function() {
 #' Loads google spreadsheet via key
 #' @export
 #' @import googlesheets
-#' @param key key of the google spreadsheet
+#' @param key sheet-identifying information; a character vector of length one holding sheet title, key, browser URL or worksheets feed OR, in the case of gs_gs only, a googlesheet object
 #' @param tab name of the tab from which data will be loaded
-gsLoadSheet <- function(key, tab) {
+#' @param verbose logical; do you want informative messages?
+#' @param lookup logical, optional. Controls whether googlesheets will place authorized API requests during registration. If unspecified, will be set to TRUE if authorization has previously been used in this R session, if working directory contains a file named .httr-oauth, or if x is a worksheets feed or googlesheet object that specifies "public" visibility.
+#' @param visibility character, either "public" or "private". Consulted during explicit construction of a worksheets feed from a key, which happens only when lookup = FALSE and googlesheets is prevented from looking up information in the spreadsheets feed. If unspecified, will be set to "public" if lookup = FALSE and "private" if lookup = TRUE. Consult the API docs for more info about visibility
+gsLoadSheet <- function(key,
+                        tab,
+                        verbose = TRUE,
+                        lookup = TRUE,
+                        visibility = "private") {
   gsAuth()
-  gap <- gs_key(key, verbose = TRUE)
-  res <- gs_read(ss = gap, ws = tab)
+  gap <- gs_key(
+    x = key,
+    verbose = TRUE,
+    lookup = lookup,
+    visibility = visibility
+    )
+  res <- gs_read(
+    ss = gap,
+    ws = tab
+    )
   data.table(res)
 }
 
 #' Loads all sheets from a google spreadsheet into a list with the tab name as the list element name.
 #' @export
 #' @import googlesheets
-#' @param key Key of the google spreadsheet.
-gsLoadAll <- function(key) {
+#' @param key sheet-identifying information; a character vector of length one holding sheet title, key, browser URL or worksheets feed OR, in the case of gs_gs only, a googlesheet object
+#' @param verbose logical; do you want informative messages?
+#' @param lookup logical, optional. Controls whether googlesheets will place authorized API requests during registration. If unspecified, will be set to TRUE if authorization has previously been used in this R session, if working directory contains a file named .httr-oauth, or if x is a worksheets feed or googlesheet object that specifies "public" visibility.
+#' @param visibility character, either "public" or "private". Consulted during explicit construction of a worksheets feed from a key, which happens only when lookup = FALSE and googlesheets is prevented from looking up information in the spreadsheets feed. If unspecified, will be set to "public" if lookup = FALSE and "private" if lookup = TRUE. Consult the API docs for more info about visibility
+gsLoadAll <- function(key,
+                      verbose = TRUE,
+                      lookup = TRUE,
+                      visibility = "private") {
   gsAuth()
   tabs <- gs_key(key)$ws$ws_title
   sheets <- lapply(tabs, function(sheet) {
-    gsLoadSheet(key = key, tab = sheet)
+    gsLoadSheet(
+      key = key,
+      tab = sheet,
+      verbose = verbose,
+      lookup = lookup,
+      visibility = visibility)
   })
   names(sheets) <- tabs
   sheets

--- a/man/bqCreatePartitionTable.Rd
+++ b/man/bqCreatePartitionTable.Rd
@@ -4,9 +4,16 @@
 \alias{bqCreatePartitionTable}
 \title{Creates partition table for a given sql}
 \usage{
-bqCreatePartitionTable(table, datasets, sql = NULL, file = NULL,
-  existing.dates = NULL, missing.dates = NULL, priority = "INTERACTIVE",
-  use.legacy.sql = bqUseLegacySql())
+bqCreatePartitionTable(
+  table,
+  datasets,
+  sql = NULL,
+  file = NULL,
+  existing.dates = NULL,
+  missing.dates = NULL,
+  priority = "INTERACTIVE",
+  use.legacy.sql = bqUseLegacySql()
+)
 }
 \arguments{
 \item{table}{name of the destination table}

--- a/man/bqCreateTable.Rd
+++ b/man/bqCreateTable.Rd
@@ -4,9 +4,15 @@
 \alias{bqCreateTable}
 \title{Creates table using given sql}
 \usage{
-bqCreateTable(sql, table, dataset = bqDefaultDataset(),
-  write.disposition = "WRITE_APPEND", priority = "INTERACTIVE",
-  use.legacy.sql = bqUseLegacySql(), schema.file = NULL)
+bqCreateTable(
+  sql,
+  table,
+  dataset = bqDefaultDataset(),
+  write.disposition = "WRITE_APPEND",
+  priority = "INTERACTIVE",
+  use.legacy.sql = bqUseLegacySql(),
+  schema.file = NULL
+)
 }
 \arguments{
 \item{sql}{string with sql statement or query template}

--- a/man/bqDataset.Rd
+++ b/man/bqDataset.Rd
@@ -11,8 +11,11 @@ bqDatasetExists(dataset = bqDefaultDataset(), project = bqDefaultProject())
 
 bqCreateDataset(dataset = bqDefaultDataset(), project = bqDefaultProject())
 
-bqDeleteDataset(dataset = bqDefaultDataset(), project = bqDefaultProject(),
-  delete.contents = FALSE)
+bqDeleteDataset(
+  dataset = bqDefaultDataset(),
+  project = bqDefaultProject(),
+  delete.contents = FALSE
+)
 
 bqDatasetTables(dataset = bqDefaultDataset(), project = bqDefaultProject())
 }

--- a/man/bqExtractTable.Rd
+++ b/man/bqExtractTable.Rd
@@ -4,8 +4,12 @@
 \alias{bqExtractTable}
 \title{Exports BigQuery table into Google Cloud Storage file}
 \usage{
-bqExtractTable(table, dataset = bqDefaultDataset(), format = "CSV",
-  compression = "GZIP")
+bqExtractTable(
+  table,
+  dataset = bqDefaultDataset(),
+  format = "CSV",
+  compression = "GZIP"
+)
 }
 \arguments{
 \item{table}{name of the table to extract}

--- a/man/bqImportData.Rd
+++ b/man/bqImportData.Rd
@@ -4,8 +4,15 @@
 \alias{bqImportData}
 \title{Imports data from gs to BigQuery table}
 \usage{
-bqImportData(table, dataset = bqDefaultDataset(), path = "",
-  append = TRUE, format = "CSV", compression = "GZIP", nskip = 1)
+bqImportData(
+  table,
+  dataset = bqDefaultDataset(),
+  path = "",
+  append = TRUE,
+  format = "CSV",
+  compression = "GZIP",
+  nskip = 1
+)
 }
 \arguments{
 \item{table}{name of the table to extract}

--- a/man/bqInsertData.Rd
+++ b/man/bqInsertData.Rd
@@ -4,8 +4,14 @@
 \alias{bqInsertData}
 \title{Inserts data into BigQuery table}
 \usage{
-bqInsertData(table, data, dataset = bqDefaultDataset(), append = TRUE,
-  fields = NULL, schema.file = NULL)
+bqInsertData(
+  table,
+  data,
+  dataset = bqDefaultDataset(),
+  append = TRUE,
+  fields = NULL,
+  schema.file = NULL
+)
 }
 \arguments{
 \item{table}{name of the target table}

--- a/man/bqInsertLargeData.Rd
+++ b/man/bqInsertLargeData.Rd
@@ -4,8 +4,14 @@
 \alias{bqInsertLargeData}
 \title{Inserts LARGE data into BigQuery table}
 \usage{
-bqInsertLargeData(table, data, dataset = bqDefaultDataset(), chunks = 5,
-  append = TRUE, schema.file = NULL)
+bqInsertLargeData(
+  table,
+  data,
+  dataset = bqDefaultDataset(),
+  chunks = 5,
+  append = TRUE,
+  schema.file = NULL
+)
 }
 \arguments{
 \item{table}{name of the target table}

--- a/man/bqProject.Rd
+++ b/man/bqProject.Rd
@@ -8,8 +8,7 @@
 \usage{
 bqProjectDatasets(project = bqDefaultProject())
 
-bqProjectTables(project = bqDefaultProject(),
-  datasets = bqProjectDatasets())
+bqProjectTables(project = bqDefaultProject(), datasets = bqProjectDatasets())
 }
 \arguments{
 \item{project}{name of the bigquery project}
@@ -18,10 +17,6 @@ bqProjectTables(project = bqDefaultProject(),
 }
 \description{
 Family of functions for common operations on projects
-
-Gets list of datasets for a given project
-
-Gets metadata of all tables of a project into a data.table
 }
 \details{
 Function queries __TABLES__ table for each dataset in the project

--- a/man/bqQuery.Rd
+++ b/man/bqQuery.Rd
@@ -43,6 +43,4 @@ Placeholders in template are replaced with values provided in ellipsis parameter
 `bqExecuteDml()` - Executes DML query without loading results
 
 `bqDownloadQuery()` Only works with Standard SQL
-
-Download results of query from a file via Storage
 }

--- a/man/bqRefreshPartitionData.Rd
+++ b/man/bqRefreshPartitionData.Rd
@@ -4,8 +4,13 @@
 \alias{bqRefreshPartitionData}
 \title{Functions to update existing partitions in the target table}
 \usage{
-bqRefreshPartitionData(table, file, ..., priority = "BATCH",
-  use.legacy.sql = bqUseLegacySql())
+bqRefreshPartitionData(
+  table,
+  file,
+  ...,
+  priority = "BATCH",
+  use.legacy.sql = bqUseLegacySql()
+)
 }
 \arguments{
 \item{table}{destination partition table where results of the query will be saved}

--- a/man/bqTable.Rd
+++ b/man/bqTable.Rd
@@ -13,8 +13,12 @@ bqTableExists(table, dataset = bqDefaultDataset())
 
 bqDeleteTable(table, dataset = bqDefaultDataset())
 
-bqInitiateTable(table, schema.file, partition = FALSE,
-  dataset = bqDefaultDataset())
+bqInitiateTable(
+  table,
+  schema.file,
+  partition = FALSE,
+  dataset = bqDefaultDataset()
+)
 
 bqPatchTable(table, schema.file, dataset = bqDefaultDataset())
 

--- a/man/bqTransformPartition.Rd
+++ b/man/bqTransformPartition.Rd
@@ -4,8 +4,14 @@
 \alias{bqTransformPartition}
 \title{Functions to transforms partitioned data form one table to another}
 \usage{
-bqTransformPartition(table, file, ..., missing.dates = NULL,
-  priority = "INTERACTIVE", use.legacy.sql = bqUseLegacySql())
+bqTransformPartition(
+  table,
+  file,
+  ...,
+  missing.dates = NULL,
+  priority = "INTERACTIVE",
+  use.legacy.sql = bqUseLegacySql()
+)
 }
 \arguments{
 \item{table}{destination partition table where results of the query will be saved}

--- a/man/gsLoadAll.Rd
+++ b/man/gsLoadAll.Rd
@@ -4,10 +4,16 @@
 \alias{gsLoadAll}
 \title{Loads all sheets from a google spreadsheet into a list with the tab name as the list element name.}
 \usage{
-gsLoadAll(key)
+gsLoadAll(key, verbose = TRUE, lookup = TRUE, visibility = "private")
 }
 \arguments{
-\item{key}{Key of the google spreadsheet.}
+\item{key}{sheet-identifying information; a character vector of length one holding sheet title, key, browser URL or worksheets feed OR, in the case of gs_gs only, a googlesheet object}
+
+\item{verbose}{logical; do you want informative messages?}
+
+\item{lookup}{logical, optional. Controls whether googlesheets will place authorized API requests during registration. If unspecified, will be set to TRUE if authorization has previously been used in this R session, if working directory contains a file named .httr-oauth, or if x is a worksheets feed or googlesheet object that specifies "public" visibility.}
+
+\item{visibility}{character, either "public" or "private". Consulted during explicit construction of a worksheets feed from a key, which happens only when lookup = FALSE and googlesheets is prevented from looking up information in the spreadsheets feed. If unspecified, will be set to "public" if lookup = FALSE and "private" if lookup = TRUE. Consult the API docs for more info about visibility}
 }
 \description{
 Loads all sheets from a google spreadsheet into a list with the tab name as the list element name.

--- a/man/gsLoadSheet.Rd
+++ b/man/gsLoadSheet.Rd
@@ -4,12 +4,18 @@
 \alias{gsLoadSheet}
 \title{Loads google spreadsheet via key}
 \usage{
-gsLoadSheet(key, tab)
+gsLoadSheet(key, tab, verbose = TRUE, lookup = TRUE, visibility = "private")
 }
 \arguments{
-\item{key}{key of the google spreadsheet}
+\item{key}{sheet-identifying information; a character vector of length one holding sheet title, key, browser URL or worksheets feed OR, in the case of gs_gs only, a googlesheet object}
 
 \item{tab}{name of the tab from which data will be loaded}
+
+\item{verbose}{logical; do you want informative messages?}
+
+\item{lookup}{logical, optional. Controls whether googlesheets will place authorized API requests during registration. If unspecified, will be set to TRUE if authorization has previously been used in this R session, if working directory contains a file named .httr-oauth, or if x is a worksheets feed or googlesheet object that specifies "public" visibility.}
+
+\item{visibility}{character, either "public" or "private". Consulted during explicit construction of a worksheets feed from a key, which happens only when lookup = FALSE and googlesheets is prevented from looking up information in the spreadsheets feed. If unspecified, will be set to "public" if lookup = FALSE and "private" if lookup = TRUE. Consult the API docs for more info about visibility}
 }
 \description{
 Loads google spreadsheet via key

--- a/man/s3GetData.Rd
+++ b/man/s3GetData.Rd
@@ -4,8 +4,14 @@
 \alias{s3GetData}
 \title{Loads data from several files in S3 based on the path prefix}
 \usage{
-s3GetData(path, header = TRUE, bucket = s3DefaultBucket(),
-  root = s3DefaultRoot(), s3.get.fun = s3GetFile, fill = TRUE)
+s3GetData(
+  path,
+  header = TRUE,
+  bucket = s3DefaultBucket(),
+  root = s3DefaultRoot(),
+  s3.get.fun = s3GetFile,
+  fill = TRUE
+)
 }
 \arguments{
 \item{path}{is the path to the S3 object}

--- a/man/s3GetFile.Rd
+++ b/man/s3GetFile.Rd
@@ -11,15 +11,23 @@
 \usage{
 s3GetFile(path, bucket = s3DefaultBucket(), root = s3DefaultRoot(), ...)
 
-s3GetFile.csv(path, bucket = s3DefaultBucket(), root = s3DefaultRoot(),
-  header = TRUE)
+s3GetFile.csv(
+  path,
+  bucket = s3DefaultBucket(),
+  root = s3DefaultRoot(),
+  header = TRUE
+)
 
 s3GetFile.gz(path, bucket = s3DefaultBucket(), root = s3DefaultRoot())
 
 s3GetFile.rds(path, bucket = s3DefaultBucket(), root = s3DefaultRoot())
 
-s3GetFile.zip(path, bucket = s3DefaultBucket(), root = s3DefaultRoot(),
-  fread.fill = FALSE)
+s3GetFile.zip(
+  path,
+  bucket = s3DefaultBucket(),
+  root = s3DefaultRoot(),
+  fread.fill = FALSE
+)
 
 s3GetFile.json.gz(path, bucket = s3DefaultBucket(), root = s3DefaultRoot())
 }

--- a/man/s3PutFile.Rd
+++ b/man/s3PutFile.Rd
@@ -10,16 +10,25 @@
 \usage{
 s3PutFile(dt, path, bucket = s3DefaultBucket(), root = s3DefaultRoot(), ...)
 
-s3PutFile.csv(dt, path, bucket = s3DefaultBucket(), root = s3DefaultRoot(),
-  na.value = "")
+s3PutFile.csv(
+  dt,
+  path,
+  bucket = s3DefaultBucket(),
+  root = s3DefaultRoot(),
+  na.value = ""
+)
 
-s3PutFile.gz(dt, path, bucket = s3DefaultBucket(), root = s3DefaultRoot(),
-  na.value = "")
+s3PutFile.gz(
+  dt,
+  path,
+  bucket = s3DefaultBucket(),
+  root = s3DefaultRoot(),
+  na.value = ""
+)
 
 s3PutFile.rds(dt, path, bucket = s3DefaultBucket(), root = s3DefaultRoot())
 
-s3PutFile.json.gz(dt, path, bucket = s3DefaultBucket(),
-  root = s3DefaultRoot())
+s3PutFile.json.gz(dt, path, bucket = s3DefaultBucket(), root = s3DefaultRoot())
 }
 \arguments{
 \item{dt}{data.table to save}

--- a/news.md
+++ b/news.md
@@ -1,5 +1,10 @@
 # RETL Package Updates
 
+## 0.1.27
+
+* `gsLoadSheet()` - add verbose, lookup and visibility params which were taking default values and was causing issues when loading private sheet.
+* `gsLoadAll()` - add verbose, lookup and visibility params to be passed to `gsLoadSheet()`.
+
 ## 0.1.26
 
 * `s3GetFile.zip()` - add fread.fill param to function to prevent R session error on large files

--- a/packrat/packrat.lock
+++ b/packrat/packrat.lock
@@ -13,6 +13,13 @@ Source: CRAN
 Version: 1.0.0
 Hash: 6abedd7919c4457604c0aa44529a6683
 
+Package: DT
+Source: CRAN
+Version: 0.10
+Hash: fc72eb88d7b291d56f9c7eac8ab6e94a
+Requires: crosstalk, htmltools, htmlwidgets, jsonlite, magrittr,
+    promises
+
 Package: MASS
 Source: CRAN
 Version: 7.3-48
@@ -40,6 +47,11 @@ Source: CRAN
 Version: 2.2.2
 Hash: b2366cd9d2f3851a5704b4e192b985c2
 
+Package: RColorBrewer
+Source: CRAN
+Version: 1.1-2
+Hash: c0d56cd15034f395874c870141870c25
+
 Package: RPostgreSQL
 Source: CRAN
 Version: 0.6-2
@@ -53,9 +65,15 @@ Hash: d04e441a8d398e3d3a71f294c07fa94d
 
 Package: RcppArmadillo
 Source: CRAN
-Version: 0.9.800.1.0
-Hash: d6b178338155965c4f90681fa048cdac
+Version: 0.9.800.3.0
+Hash: e10fb782dd44b7a079067d9bd6aa5197
 Requires: Rcpp
+
+Package: askpass
+Source: CRAN
+Version: 1.1
+Hash: 6f6c430e3cd0dd7d48f447700f4d7e7f
+Requires: sys
 
 Package: assertthat
 Source: CRAN
@@ -63,14 +81,10 @@ Version: 0.2.1
 Hash: 622be49032fe50bd42e96aaef613e209
 
 Package: aws.signature
-Source: github
-Version: 0.4.5
-Hash: 49686bde0575720d3059afb97f2c0b20
+Source: CRAN
+Version: 0.5.2
+Hash: 1b3472eb16889a56bc6938ac295793d8
 Requires: base64enc, digest
-GithubRepo: aws.signature
-GithubUsername: cloudyr
-GithubRef: master
-GithubSha1: df1ddb4931d755bb83cd7f05937be0d7129f46fb
 
 Package: backports
 Source: CRAN
@@ -122,8 +136,8 @@ Requires: bitops
 
 Package: callr
 Source: CRAN
-Version: 3.3.2
-Hash: 7661e5194cbbe511957b2fb621516c1b
+Version: 3.4.0
+Hash: ae27c37525b77ec1a7b387cd9451219d
 Requires: R6, processx
 
 Package: cellranger
@@ -134,9 +148,24 @@ Requires: rematch, tibble
 
 Package: cli
 Source: CRAN
-Version: 1.1.0
-Hash: bc4e54014c2049f2605ad0c3ba0cce6b
-Requires: assertthat, crayon
+Version: 2.0.0
+Hash: 22feb93c52edcf5d1d9861e92fa33c91
+Requires: assertthat, crayon, fansi, glue
+
+Package: clipr
+Source: CRAN
+Version: 0.7.0
+Hash: 30cdec6c8cc62c80c485e6bdd0c02b05
+
+Package: clisymbols
+Source: CRAN
+Version: 1.2.0
+Hash: a76a309884277a4fd8a5d741965fbef5
+
+Package: colorspace
+Source: CRAN
+Version: 1.4-1
+Hash: 60a56e9998b8b58ee378db3dc91b27a5
 
 Package: commonmark
 Source: CRAN
@@ -145,14 +174,20 @@ Hash: ef9740410f8fcf978782a7aa76eaba2b
 
 Package: covr
 Source: CRAN
-Version: 3.0.1
-Hash: aab7a1873ad3d943dd4a0ce4edbc2691
-Requires: crayon, httr, jsonlite, rex, withr
+Version: 3.4.0
+Hash: 73e128a954d3aaeac8d088dab50975d9
+Requires: crayon, digest, httr, jsonlite, rex, withr, yaml
 
 Package: crayon
 Source: CRAN
 Version: 1.3.4
 Hash: ff2840dd9b0d563fc80377a5a45510cd
+
+Package: crosstalk
+Source: CRAN
+Version: 1.0.0
+Hash: c13adea5906fbe2becfcb5f843b26749
+Requires: R6, ggplot2, htmltools, jsonlite, lazyeval, shiny
 
 Package: curl
 Source: CRAN
@@ -172,16 +207,18 @@ Hash: b1642cf2ee0ab1d1b152ffacdb4401f7
 
 Package: desc
 Source: CRAN
-Version: 1.1.0
-Hash: 41affe2afec43393f77731b1d761b3b3
+Version: 1.2.0
+Hash: a0a3ca939997679a52816bae4ed6aaae
 Requires: R6, assertthat, crayon, rprojroot
 
 Package: devtools
 Source: CRAN
-Version: 1.12.0
-Hash: bbad95109ae75cbb14099281cda43af2
-Requires: digest, git2r, httr, jsonlite, memoise, rstudioapi, whisker,
-    withr
+Version: 2.2.1
+Hash: 9baf6de0ef44d3ee36db7d022ac4c37a
+Requires: DT, callr, cli, covr, crayon, desc, digest, ellipsis, git2r,
+    glue, httr, jsonlite, memoise, pkgbuild, pkgload, rcmdcheck,
+    remotes, rlang, roxygen2, rstudioapi, rversions, sessioninfo,
+    testthat, usethis, withr
 
 Package: digest
 Source: CRAN
@@ -190,15 +227,36 @@ Hash: cfce0bc7ed5ba0cdc47182698fae1d24
 
 Package: dplyr
 Source: CRAN
-Version: 0.5.0
-Hash: 856c09fd74dffe0364405cd746aa1ade
-Requires: BH, DBI, R6, Rcpp, assertthat, lazyeval, magrittr, tibble
+Version: 0.8.3
+Hash: 339a50ed16deb5c28bffa801532a04ad
+Requires: BH, R6, Rcpp, assertthat, glue, magrittr, pkgconfig, plogr,
+    rlang, tibble, tidyselect
+
+Package: ellipsis
+Source: CRAN
+Version: 0.3.0
+Hash: 30b58109e4d7c6184a9c2e32f9ae38c6
+Requires: rlang
 
 Package: evaluate
 Source: CRAN
-Version: 0.10.1
-Hash: 54d95f4ec6d0300100413ed0127d89ae
-Requires: stringr
+Version: 0.14
+Hash: 18306cc3bc1aec7b7360eea8a0eb0ee1
+
+Package: fansi
+Source: CRAN
+Version: 0.4.0
+Hash: f147621f72b561485bfffcae78c4f5d5
+
+Package: farver
+Source: CRAN
+Version: 2.0.1
+Hash: eb671f52c8ebb4b81617eba93abda72b
+
+Package: fastmap
+Source: CRAN
+Version: 1.0.1
+Hash: d272cd728e4095b3964181b44763f46c
 
 Package: formatR
 Source: CRAN
@@ -206,24 +264,29 @@ Version: 1.4
 Hash: b2a47a2b91737978cf50ba95825a9cd1
 
 Package: fs
-Source: github
-Version: 1.3.1.9000
-Hash: 521670bf69bdbc3f46646477e699c730
+Source: CRAN
+Version: 1.3.1
+Hash: 104f1ba37405da6eb4d2391f7c02aaba
 Requires: Rcpp
-GithubRepo: fs
-GithubUsername: r-lib
-GithubRef: master
-GithubSha1: 380685c7fc0a3346b5ea0e6db127d8ca09a813a1
 
 Package: gargle
-Source: github
-Version: 0.4.0.9000
-Hash: ccdc12b8bc25b57ed1bdd96316c0ed36
+Source: CRAN
+Version: 0.4.0
+Hash: 7e47b2d96f1d6839aa0d28ed9c1a353e
 Requires: fs, glue, httr, jsonlite, rlang, withr
-GithubRepo: gargle
-GithubUsername: r-lib
-GithubRef: master
-GithubSha1: 8c05dd0b7276cf464524f4e72cdd160370fb71e2
+
+Package: ggplot2
+Source: CRAN
+Version: 3.2.1
+Hash: 7cf3f9df0089475f133ec23befca1032
+Requires: MASS, digest, gtable, lazyeval, reshape2, rlang, scales,
+    tibble, viridisLite, withr
+
+Package: gh
+Source: CRAN
+Version: 1.0.1
+Hash: 3f8812accd1320227d744bca620e8c42
+Requires: httr, ini, jsonlite
 
 Package: git2r
 Source: CRAN
@@ -231,13 +294,9 @@ Version: 0.26.1
 Hash: 744a0a12d9f4ac186b222f6795fab4fe
 
 Package: glue
-Source: github
-Version: 1.3.1.9000
-Hash: 6343e6e5d470cf12e760c9660a3d49d1
-GithubRepo: glue
-GithubUsername: tidyverse
-GithubRef: master
-GithubSha1: 71eeddfa43763880ccc6afd9021553fd728b1821
+Source: CRAN
+Version: 1.3.1
+Hash: 660bbbe3803c7cf7c9489a7d99a9c0ed
 
 Package: googleAuthR
 Source: CRAN
@@ -259,6 +318,11 @@ Hash: b317d6b5f8bdf48f56a5789f80b883bd
 Requires: cellranger, dplyr, httr, jsonlite, purrr, readr, stringr,
     tidyr, xml2
 
+Package: gtable
+Source: CRAN
+Version: 0.3.0
+Hash: a9e7b0666eb933a0cb36779240b4462e
+
 Package: highr
 Source: CRAN
 Version: 0.7
@@ -272,9 +336,15 @@ Requires: pkgconfig, rlang
 
 Package: htmltools
 Source: CRAN
-Version: 0.3.5
-Hash: 0e58a6e9d5dc4bb1051b109c103902e2
-Requires: Rcpp, digest
+Version: 0.4.0
+Hash: 3f49193aa22146296cee8ae091b6303a
+Requires: Rcpp, digest, rlang
+
+Package: htmlwidgets
+Source: CRAN
+Version: 1.5.1
+Hash: 20e5cc02b795afc7322836c947b5aab2
+Requires: htmltools, jsonlite, yaml
 
 Package: httptest
 Source: github
@@ -288,9 +358,9 @@ GithubSha1: 260c0aad98332321e13b9dc03c20859b56cc2f6b
 
 Package: httpuv
 Source: CRAN
-Version: 1.3.3
-Hash: 38a354d3a524854049c3b902c221b2f9
-Requires: Rcpp
+Version: 1.5.2
+Hash: 7399dde6fe7d304dfc04623f91b3d1e3
+Requires: BH, R6, Rcpp, later, promises
 
 Package: httr
 Source: CRAN
@@ -303,6 +373,11 @@ Source: CRAN
 Version: 1.2.4.2
 Hash: 13fd902945ea53bda3f78d1b6c619bf6
 Requires: magrittr, pkgconfig
+
+Package: ini
+Source: CRAN
+Version: 0.3.1
+Hash: 9d6de5178c1cedabfb24e7d2acc9a092
 
 Package: irlba
 Source: CRAN
@@ -320,6 +395,17 @@ Version: 1.20
 Hash: 9c6b215d1d02b97586c8232e94533e6a
 Requires: evaluate, highr, markdown, stringr, yaml
 
+Package: labeling
+Source: CRAN
+Version: 0.3
+Hash: ecf589b42cd284b03a4beb9665482d3e
+
+Package: later
+Source: CRAN
+Version: 1.0.0
+Hash: 77f0aa863b2088b644beba04288942d1
+Requires: BH, Rcpp, rlang
+
 Package: lattice
 Source: CRAN
 Version: 0.20-35
@@ -327,8 +413,14 @@ Hash: 4cf72973da5480d40d5ee94d93eebb9c
 
 Package: lazyeval
 Source: CRAN
-Version: 0.2.0
-Hash: 3d6e7608e65bbf5cb170dab1e3c9ed8b
+Version: 0.2.2
+Hash: 563563691bea3cde6945a98996d7c166
+
+Package: lifecycle
+Source: CRAN
+Version: 0.1.0
+Hash: fd2ceffa778c010fab2df12b2eccd835
+Requires: glue, rlang
 
 Package: lintr
 Source: CRAN
@@ -356,8 +448,8 @@ Requires: digest
 
 Package: mime
 Source: CRAN
-Version: 0.5
-Hash: 463550cf44fb6f0a2359368f42eebe62
+Version: 0.7
+Hash: 0d7563caf453c231b6f8c359c51eecc2
 
 Package: miniUI
 Source: CRAN
@@ -371,25 +463,55 @@ Version: 0.4.1
 Hash: bce6846bd2ed0a41b7cba564bd816dac
 Requires: testthat
 
+Package: munsell
+Source: CRAN
+Version: 0.5.0
+Hash: 38d0efee9bb99bef143bde41c4ce715c
+Requires: colorspace
+
 Package: openssl
 Source: CRAN
-Version: 0.9.9
-Hash: 3858537ac10388a5db1687450908f257
+Version: 1.4.1
+Hash: b01fe6ae05ec2a30a777dc338af5bf69
+Requires: askpass
 
 Package: packrat
 Source: CRAN
 Version: 0.5.0
 Hash: 498643e765d1442ba7b1160a1df3abf9
 
+Package: pillar
+Source: CRAN
+Version: 1.4.2
+Hash: 28ff1862b4e0c8761efca442e80a63d8
+Requires: cli, crayon, fansi, rlang, utf8, vctrs
+
+Package: pkgbuild
+Source: CRAN
+Version: 1.0.6
+Hash: f41de345bf0dda984cce64a7ea668ea4
+Requires: R6, callr, cli, crayon, desc, prettyunits, rprojroot, withr
+
 Package: pkgconfig
 Source: CRAN
-Version: 2.0.1
-Hash: 0dda4a2654a22b36a715c2b0b6fbacac
+Version: 2.0.3
+Hash: 5ff5f2361851a49534c96caa2a8071c7
+
+Package: pkgload
+Source: CRAN
+Version: 1.0.2
+Hash: 41eb2db35be61f6f9e8864cf87a1ecb0
+Requires: desc, pkgbuild, rlang, rprojroot, rstudioapi, withr
+
+Package: plogr
+Source: CRAN
+Version: 0.2.0
+Hash: 81a8008a5e7858552503935f1abe48aa
 
 Package: plyr
 Source: CRAN
-Version: 1.8.4
-Hash: 5c3737d7c1846e30d40c8c38110b5fcd
+Version: 1.8.5
+Hash: 203e2926eebb494b8b9fa04cced811e7
 Requires: Rcpp
 
 Package: praise
@@ -415,6 +537,12 @@ Version: 1.1.2
 Hash: ceef88c244d792a874bdacf72b6a30da
 Requires: R6, prettyunits
 
+Package: promises
+Source: CRAN
+Version: 1.1.0
+Hash: 39e1f8afe2fdb00b01144024fec6f4ba
+Requires: R6, Rcpp, later, magrittr, rlang
+
 Package: ps
 Source: CRAN
 Version: 1.3.0
@@ -422,9 +550,9 @@ Hash: 1d4cae95887ffe5b1a22bea5994476cd
 
 Package: purrr
 Source: CRAN
-Version: 0.2.2
-Hash: e95d7ee8b0782024b9158b4f0e800bf3
-Requires: BH, Rcpp, dplyr, lazyeval, magrittr
+Version: 0.3.3
+Hash: d4f497f8a97ef6c7182a87b2476748d1
+Requires: magrittr, rlang
 
 Package: rGoodData
 Source: CRAN
@@ -440,6 +568,13 @@ GithubRepo: rapidjsonr
 GithubUsername: SymbolixAU
 GithubRef: master
 GithubSha1: a7e0502c1f516a49dcc6b436e2df6fad23ed534e
+
+Package: rcmdcheck
+Source: CRAN
+Version: 1.3.3
+Hash: df2319559a8ed16e5b4d5f99de3e00a0
+Requires: R6, callr, cli, crayon, desc, digest, pkgbuild, prettyunits,
+    rprojroot, sessioninfo, withr, xopen
 
 Package: readr
 Source: CRAN
@@ -459,8 +594,8 @@ Hash: 3e0c7be315f7373f63989166181bfdcb
 
 Package: reshape2
 Source: CRAN
-Version: 1.4.2
-Hash: fd40380842d0aef6c71b9329d8d84215
+Version: 1.4.3
+Hash: b7ea8a2e7a9df39c2346e78bd83e26f8
 Requires: Rcpp, plyr, stringr
 
 Package: rex
@@ -471,33 +606,52 @@ Requires: lazyeval, magrittr
 
 Package: rlang
 Source: CRAN
-Version: 0.4.0
-Hash: eabda67321fe1d477ea641ddd5d84f00
+Version: 0.4.2
+Hash: c5cfcde637bbff4e42edad2e69dac5c7
 
 Package: roxygen2
 Source: CRAN
-Version: 6.0.1
-Hash: 81bf0fc180f2fd243a965fe8b0f1c4ee
-Requires: R6, Rcpp, brew, commonmark, desc, digest, stringi, stringr,
-    xml2
+Version: 7.0.2
+Hash: 452c89f55863d82d857267833437ce22
+Requires: R6, Rcpp, brew, commonmark, desc, digest, pkgload, purrr,
+    rlang, stringi, stringr, xml2
 
 Package: rprojroot
 Source: CRAN
-Version: 1.2
-Hash: fdcac51a7f47decd60556ceefc3c26b1
+Version: 1.3-2
+Hash: a25c3f70c166fb3fbabc410eb32b6366
 Requires: backports
 
 Package: rstudioapi
 Source: CRAN
-Version: 0.6
-Hash: fd256f8bfb9a64cc35f98b0decb1a79f
+Version: 0.10
+Hash: 63f43c6ff14d92e1d65ca6c21d45a1eb
+
+Package: rversions
+Source: CRAN
+Version: 2.0.1
+Hash: d2080f9ec93e7b4e3729c195ef1f9908
+Requires: curl, xml2
+
+Package: scales
+Source: CRAN
+Version: 1.1.0
+Hash: fa53af4e3ceba05fc79a31bde5962445
+Requires: R6, RColorBrewer, farver, labeling, lifecycle, munsell,
+    viridisLite
+
+Package: sessioninfo
+Source: CRAN
+Version: 1.1.1
+Hash: 9e50c8458e611f166ba702277cbb5096
+Requires: cli, withr
 
 Package: shiny
 Source: CRAN
-Version: 1.0.1
-Hash: 26d81d2e377b54e68a02f3651c39df81
-Requires: R6, digest, htmltools, httpuv, jsonlite, mime, sourcetools,
-    xtable
+Version: 1.4.0
+Hash: 7a1d8725849ecb792b4df2c084769c23
+Requires: R6, crayon, digest, fastmap, htmltools, httpuv, jsonlite,
+    later, mime, promises, rlang, sourcetools, xtable
 
 Package: sodium
 Source: CRAN
@@ -506,8 +660,8 @@ Hash: fefcc4853ec7eedb939924477189da52
 
 Package: sourcetools
 Source: CRAN
-Version: 0.1.6
-Hash: 226d56d7469587da40b0f96180e711b4
+Version: 0.1.7
+Hash: d093478ac90064e670cd4bf1a99b47b6
 
 Package: stringdist
 Source: CRAN
@@ -521,22 +675,27 @@ Hash: ed2a82fc7cc668c1345223d938cdfaf2
 
 Package: stringr
 Source: CRAN
-Version: 1.2.0
-Hash: 25a86d7f410513ebb7c0bc6a5e16bdc3
-Requires: magrittr, stringi
+Version: 1.4.0
+Hash: 67da32dbb2a7a16f2ef124336358e54a
+Requires: glue, magrittr, stringi
+
+Package: sys
+Source: CRAN
+Version: 3.3
+Hash: d5a4afad9298f42aae77f6389713a066
 
 Package: testthat
 Source: CRAN
-Version: 2.2.1
-Hash: ec68d8eb0203c88d5efa62e67fba2a97
-Requires: R6, cli, crayon, digest, evaluate, magrittr, praise, rlang,
-    withr
+Version: 2.3.1
+Hash: 08a7645752835e2708c9bdf681409532
+Requires: R6, cli, crayon, digest, ellipsis, evaluate, magrittr,
+    pkgload, praise, rlang, withr
 
 Package: tibble
 Source: CRAN
-Version: 1.3.4
-Hash: 39c056f3cadf33c6472b7520505cb309
-Requires: Rcpp, rlang
+Version: 2.1.3
+Hash: f59680d81ddc45fa3fcb8c07686d1d89
+Requires: cli, crayon, fansi, pillar, pkgconfig, rlang
 
 Package: tidyr
 Source: CRAN
@@ -544,10 +703,39 @@ Version: 0.6.1
 Hash: 89fe0243a2457301b2209f341cfee2a1
 Requires: Rcpp, dplyr, lazyeval, magrittr, stringi, tibble
 
+Package: tidyselect
+Source: CRAN
+Version: 0.2.5
+Hash: 9ab4ed03f4b7bbdbd1db9d7a920aae1a
+Requires: Rcpp, glue, purrr, rlang
+
+Package: usethis
+Source: CRAN
+Version: 1.5.1
+Hash: 1a3f09efcce670dc6a5562cfd3c71d66
+Requires: clipr, clisymbols, crayon, curl, desc, fs, gh, git2r, glue,
+    purrr, rlang, rprojroot, rstudioapi, whisker, withr, yaml
+
+Package: utf8
+Source: CRAN
+Version: 1.1.4
+Hash: f3f97ce59092abc8ed3fd098a59e236c
+
+Package: vctrs
+Source: CRAN
+Version: 0.2.1
+Hash: 8ba1577e36ecf03aed0660c019fe7097
+Requires: backports, digest, ellipsis, glue, rlang, zeallot
+
+Package: viridisLite
+Source: CRAN
+Version: 0.3.0
+Hash: 78bb072c4f9e729a283d4c40ec93f9c6
+
 Package: whisker
 Source: CRAN
-Version: 0.3-2
-Hash: 803d662762e532705c2c066a82d066e7
+Version: 0.4
+Hash: 5b1ec05cd96c1e0c6048bab49abee3aa
 
 Package: withr
 Source: CRAN
@@ -556,19 +744,25 @@ Hash: d534108bcd5f34ec73e9eb523751ba20
 
 Package: xml2
 Source: CRAN
-Version: 1.1.1
-Hash: a6bf062f3acf5fbdd49b8aced7f210e4
-Requires: BH, Rcpp
+Version: 1.2.2
+Hash: c5258a3beb15da46d4682eda667bf5ec
+Requires: Rcpp
 
 Package: xmlparsedata
 Source: CRAN
 Version: 1.0.3
 Hash: 4040c9b60e76a9950dd171e77c338b86
 
+Package: xopen
+Source: CRAN
+Version: 1.0.0
+Hash: 22c2708f177f9fd9f8a52012bac61d6a
+Requires: processx
+
 Package: xtable
 Source: CRAN
-Version: 1.8-2
-Hash: fc07fb412c629e44331a2b8a40686452
+Version: 1.8-4
+Hash: dc0d47261b678d26032363bebd050540
 
 Package: xts
 Source: CRAN
@@ -578,8 +772,13 @@ Requires: zoo
 
 Package: yaml
 Source: CRAN
-Version: 2.1.16
-Hash: 784ea5d8302d4a81f166a32a33c10711
+Version: 2.2.0
+Hash: a5ad5616d83d89f8d84cbf3cf4034e13
+
+Package: zeallot
+Source: CRAN
+Version: 0.1.0
+Hash: 10b2ed48e202b4db421ae864041dc4b2
 
 Package: zip
 Source: CRAN

--- a/packrat/packrat.opts
+++ b/packrat/packrat.opts
@@ -7,9 +7,13 @@ external.packages:
 local.repos: 
 load.external.packages.on.startup: TRUE
 ignored.packages: aws.s3
+ignored.directories:
+    data
+    inst
 quiet.package.installation: TRUE
 snapshot.recommended.packages: FALSE
 snapshot.fields:
     Imports
     Depends
     LinkingTo
+symlink.system.packages: TRUE


### PR DESCRIPTION
- As trying to pull data from a private sheet, I realised that some params were for now defaulted. I have added `verbose`, `lookup` and `visibility` params to our functions if anyone need to pass them. 

- Also updated packrat as it seemed working quite well.