### PR TITLE
Replaced cat() with message as it causes unwanted output

### DIFF
--- a/R/bigquery-execute.R
+++ b/R/bigquery-execute.R
@@ -102,8 +102,10 @@ bqExecuteDml <- function(query, ...,
   )
 
   if (length(params) > 0) {
-    cat("parameters applied to the template: \n")
-    message(jsonlite::toJSON(params, auto_unbox = TRUE, force = TRUE))
+    message(
+      "parameters applied to the template: \n",
+      jsonlite::toJSON(params, auto_unbox = TRUE, force = TRUE)
+    )
   }
 
   ds <- bq_dataset(


### PR DESCRIPTION
`cat()` call inside `bqExecuteQuery` was creating unwanted output in markdown files.