### PR TITLE
Lock bigquery upload of large files to use timestamp string in the js…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: retl
 Type: Package
 Title: Support for common ETL operations and connections
-Version: 0.1.37
+Version: 0.1.38
 Date: 2020-03-12
 Author: byapparov@gmail.com
 Maintainer: Bulat Yapparov <byapparov@gmail.com>

--- a/R/bigquery.R
+++ b/R/bigquery.R
@@ -61,7 +61,11 @@ bqInsertLargeData <- function(table,
   })
 
   # Save data to local temporary file
-  jsonlite::stream_out(data, file(temp.filename))
+  jsonlite::stream_out(
+    x = data,
+    con = file(temp.filename),
+    POSIXt = "ISO8601"
+  )
 
   googleCloudStorageR::gcs_upload(
     file = temp.filename,

--- a/news.md
+++ b/news.md
@@ -1,5 +1,9 @@
 # RETL Package Updates
 
+## 0.1.38
+
+* `bqInsertLargeData()` - lock json output for POSIXt to ISO8601 format.
+
 ## 0.1.37
 
 * `GCS_DEFAULT_BUCKET` envar changed to previous `GCS_BUCKET` as it is already being used.


### PR DESCRIPTION
…on output