### PR TITLE
Added tests to confirm that descriptions persist on table creation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: retl
 Type: Package
 Title: Support for common ETL operations and connections
-Version: 0.1.38
+Version: 0.1.39
 Date: 2020-03-12
 Author: byapparov@gmail.com
 Maintainer: Bulat Yapparov <byapparov@gmail.com>

--- a/R/bigquery-execute.R
+++ b/R/bigquery-execute.R
@@ -239,6 +239,33 @@ bqCreateTable <- function(sql,
     message("Initiated successfully")
   }
 
+  if (write.disposition == "WRITE_TRUNCATE" && !contains_partition(table)) {
+    # https://cloud.google.com/bigquery/docs/reference/rest/v2/Job
+    # > schemaUpdateOptions[]: For normal tables, WRITE_TRUNCATE will always overwrite the schema.
+
+    # Partition tables are excluded from this flow as schema is not affected
+    # by query results being saved into a partition.
+
+    bq.table <-  bq_table(
+      project = Sys.getenv("BIGQUERY_PROJECT"),
+      dataset = dataset,
+      table = table
+    )
+    table.meta <- bq_table_meta(bq.table)
+    on.exit(
+      # compensate for unwanted behaviour of BigQuery
+      bq_table_patch(bq.table, table.meta$schema$fields)
+
+      # This is not ideal as it will not fail early and table
+      # can be overwritten with wrong schema and fail on patch (which is too late)
+
+      # @byapparov:
+      # I have also tried `CREATE OR REPLACE  DML approach:
+      # https://stackoverflow.com/a/58538111/599911
+      # This does not work for partitioned tables hence was abondoned.
+    )
+  }
+
   args <- c(as.list(environment()), list(...))
 
   if (use.legacy.sql) {
@@ -342,3 +369,5 @@ message_params <- function(x) { # nolint
     )
   }
 }
+
+contains_partition <- function(x) grepl("\\$", x) # nolint

--- a/R/bigquery-execute.R
+++ b/R/bigquery-execute.R
@@ -253,7 +253,7 @@ bqCreateTable <- function(sql,
 
     # Extract named arguments and turn them into query params
     args.reserved <- c(
-      "query",
+      "sql",
       "table",
       "dataset",
       "write.disposition",

--- a/news.md
+++ b/news.md
@@ -1,5 +1,12 @@
 # RETL Package Updates
 
+## 0.1.39
+
+* `bqCreateTable()` - Now keeps field descriptions on `WRITE_TRUNCATE` desponsition through a workaround.
+  See: https://cloud.google.com/bigquery/docs/reference/rest/v2/Job
+  
+  > schemaUpdateOptions[]: For normal tables, WRITE_TRUNCATE will always overwrite the schema.
+
 ## 0.1.38
 
 * `bqInsertLargeData()` - lock json output for POSIXt to ISO8601 format.

--- a/tests/testthat/bq-table-schema.json
+++ b/tests/testthat/bq-table-schema.json
@@ -1,7 +1,8 @@
 [
   {
     "name": "id",
-    "type": "INTEGER"
+    "type": "INTEGER",
+    "description": "Unique Identifier"
   },
   {
     "name": "first_name",

--- a/tests/testthat/test.bq.query.R
+++ b/tests/testthat/test.bq.query.R
@@ -199,4 +199,18 @@ test_that("Table can be created from query", {
   meta <- bq_table_meta(table.test.create)
   expect_equal(meta$schema$fields[[1]]$description, "Unique Identifier")
   expect_equal(meta$numRows, "1") # check that table was truncated
+
+
+  # Truncate table and query with wrong schema will fail
+  # This confirms that we can change breaking schema changes initiated by sql
+  expect_error(
+    bqCreateTable(
+      sql = "SELECT CAST(@value AS INT64) AS new_field",
+      table = table.test.create$table,
+      write.disposition = "WRITE_TRUNCATE",
+      use.legacy.sql = FALSE,
+      value = 2
+    ),
+    regexp = "new_field is missing"
+  )
 })

--- a/tests/testthat/test.bq.query.R
+++ b/tests/testthat/test.bq.query.R
@@ -180,5 +180,5 @@ test_that("Table can be created from query", {
   # Check that field descriptions persist with `WRITE_TRUNCATE` option
   meta <- bq_table_meta(table.test.create)
   expect_equal(meta$schema$fields[[1]]$description, "Unique Identifier")
-
+  expect_equal(meta$numRows, "1") # check that table was truncated
 })

--- a/tests/testthat/test.bq.query.R
+++ b/tests/testthat/test.bq.query.R
@@ -184,15 +184,12 @@ test_that("Table can be created from query", {
 
 
   # Truncate table and insert new data from query without schema file
-  expect_warning(
-    bqCreateTable(
-      sql = "SELECT CAST(@value AS INT64) AS id",
-      table = table.test.create$table,
-      write.disposition = "WRITE_TRUNCATE",
-      use.legacy.sql = FALSE,
-      value = 2
-    ),
-    regexp = "attempting patch"
+  bqCreateTable(
+    sql = "SELECT CAST(@value AS INT64) AS id",
+    table = table.test.create$table,
+    write.disposition = "WRITE_TRUNCATE",
+    use.legacy.sql = FALSE,
+    value = 2
   )
 
   # Check that field descriptions persist with `WRITE_TRUNCATE` option
@@ -211,6 +208,7 @@ test_that("Table can be created from query", {
       use.legacy.sql = FALSE,
       value = 2
     ),
+    class = "bigrquery_invalid",
     regexp = "new_field is missing"
   )
 })

--- a/tests/testthat/test.bq.query.R
+++ b/tests/testthat/test.bq.query.R
@@ -181,4 +181,22 @@ test_that("Table can be created from query", {
   meta <- bq_table_meta(table.test.create)
   expect_equal(meta$schema$fields[[1]]$description, "Unique Identifier")
   expect_equal(meta$numRows, "1") # check that table was truncated
+
+
+  # Truncate table and insert new data from query without schema file
+  expect_warning(
+    bqCreateTable(
+      sql = "SELECT CAST(@value AS INT64) AS id",
+      table = table.test.create$table,
+      write.disposition = "WRITE_TRUNCATE",
+      use.legacy.sql = FALSE,
+      value = 2
+    ),
+    regexp = "attempting patch"
+  )
+
+  # Check that field descriptions persist with `WRITE_TRUNCATE` option
+  meta <- bq_table_meta(table.test.create)
+  expect_equal(meta$schema$fields[[1]]$description, "Unique Identifier")
+  expect_equal(meta$numRows, "1") # check that table was truncated
 })


### PR DESCRIPTION
for existing table if schema does not change.