### PR TITLE
Hotfix: gsLoadAll()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: retl
 Type: Package
 Title: Support for common ETL operations and connections
-Version: 0.1.41
+Version: 0.1.40
 Date: 2020-10-13
 Author: byapparov@gmail.com
 Maintainer: Bulat Yapparov <byapparov@gmail.com>

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: retl
 Type: Package
 Title: Support for common ETL operations and connections
-Version: 0.1.40
-Date: 2020-10-12
+Version: 0.1.41
+Date: 2020-10-13
 Author: byapparov@gmail.com
 Maintainer: Bulat Yapparov <byapparov@gmail.com>
 Description: Wrappers for connections with PostgreSQL, S3, BigQuery, InfluxDB, Doubleclick.

--- a/R/googlespreadsheets.R
+++ b/R/googlespreadsheets.R
@@ -59,13 +59,13 @@ gsLoadAll <- function(key,
   gsAuth()
   tabs <- gs_key(key)$ws$ws_title
   sheets <- lapply(tabs, function(sheet) {
+    Sys.sleep(6)
     gsLoadSheet(
       key = key,
       tab = sheet,
       verbose = verbose,
       lookup = lookup,
       visibility = visibility)
-    Sys.sleep(6)
   })
   names(sheets) <- tabs
   sheets

--- a/news.md
+++ b/news.md
@@ -1,8 +1,14 @@
 # RETL Package Updates
 
+# RETL Package Updates
+
+## 0.1.41
+
+* `gsLoadAll()` - Fixed `Sys.sleep(6)` for each call
+
 ## 0.1.40
 
-* `gsLoadSheet()` - Added `Sys.sleep(6)` after each call
+* `gsLoadAll()` - Added `Sys.sleep(6)` after each call
 
 ## 0.1.39
 

--- a/news.md
+++ b/news.md
@@ -2,13 +2,9 @@
 
 # RETL Package Updates
 
-## 0.1.41
-
-* `gsLoadAll()` - Fixed `Sys.sleep(6)` for each call
-
 ## 0.1.40
 
-* `gsLoadAll()` - Added `Sys.sleep(6)` after each call
+* `gsLoadAll()` - Added `Sys.sleep(6)` before each call
 
 ## 0.1.39
 

--- a/news.md
+++ b/news.md
@@ -1,7 +1,5 @@
 # RETL Package Updates
 
-# RETL Package Updates
-
 ## 0.1.40
 
 * `gsLoadAll()` - Added `Sys.sleep(6)` before each call


### PR DESCRIPTION
- last version (0.1.40) added wait to `gsLoadAll()`
- but each loop returns the output of the last command `Sys.sleep(6)`, i.e. NULL
- therefore I moved the `Sys.sleep(6)` before the function call in the loop.